### PR TITLE
Fix default previous level for calculations

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
                 <select id="nivelAnterior">
                     <option value="0">Capilla</option>
                     <option value="1">Junior</option>
-                    <option value="2">Senior A</option>
+                    <option value="2" selected>Senior A</option>
                     <option value="3">Senior B</option>
                     <option value="4">Máster</option>
                     <option value="5">Genio</option>


### PR DESCRIPTION
## Summary
- ensure `Nivel anterior` defaults to **Senior A** for baseline calculation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ee040d668832f895ac5d52f632d31