### PR TITLE
Fix getMult for ascending multiplier tables

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -56,10 +56,15 @@ function nivelPorValor(valor, metasArr) {
 }
 
 function getMult(valor, tabla) {
+    let mult = tabla[tabla.length - 1].mult;
+    let bestMin = -Infinity;
     for (let i = 0; i < tabla.length; i++) {
-        if (valor >= tabla[i].min) return tabla[i].mult;
+        if (valor >= tabla[i].min && tabla[i].min >= bestMin) {
+            bestMin = tabla[i].min;
+            mult = tabla[i].mult;
+        }
     }
-    return tabla[tabla.length - 1].mult;
+    return mult;
 }
 
 function calcular() {


### PR DESCRIPTION
## Summary
- ensure `getMult` searches the entire table
- keep multiplier for the highest valid threshold

## Testing
- `node` manual tests for `getMult` on `multMora`

------
https://chatgpt.com/codex/tasks/task_e_685ee36b4a78832f9aedc3f3b43c3419