### PR TITLE
Add calculation unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "comisiones-comercial-sersa",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/tests/unit/calculations.test.js
+++ b/tests/unit/calculations.test.js
@@ -1,0 +1,18 @@
+const { calculateCommission } = require('../../src/app');
+
+test('SPEC 9.1 total equals 7,305,000 Gs', () => {
+  const result = calculateCommission({
+    nivelAnterior: 2, // Senior A
+    montoInterno: 900000000,
+    montoExterno: 150000000,
+    montoRecuperado: 80000000,
+    cantidad: 9,
+    menorSemana: 2,
+    conv: 8,
+    emp: 96,
+    proc: 95,
+    mora: 2,
+    nivelEquipo: 0
+  });
+  expect(result.total).toBe(7305000);
+});


### PR DESCRIPTION
## Summary
- extract commission logic into `calculateCommission`
- export the function for Node use
- add Jest unit test for SPEC example
- add test script in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee3737a1c832f82219bc6fd553d2a