### PR TITLE
Fix profile selector change handling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -71,7 +71,7 @@ let currentProfile = 'agil_1';
 function applyProfile(id) {
     const p = profiles[id] || profiles.agil_1;
     currentProfile = p.id;
-    localStorage.setItem('selectedProfile', currentProfile);
+    localStorage.setItem('currentProfile', currentProfile);
 
     niveles = cloneConfig(p.config.niveles);
     metas = cloneConfig(p.config.metas);
@@ -88,8 +88,15 @@ function applyProfile(id) {
         resetProgressBars();
         initProgressBars();
     }
+}
 
+function updateCalculations() {
     calcular();
+}
+
+function changeProfile(profileId) {
+    applyProfile(profileId);
+    updateCalculations();
 }
 
 function updateProgress(id, nivel) {
@@ -220,9 +227,6 @@ document.querySelectorAll('#datosForm input, #datosForm select').forEach(el => {
 
 document.getElementById('pdfButton').addEventListener('click', descargarPDF);
 
-const savedProfile = localStorage.getItem('selectedProfile') || 'agil_1';
+const savedProfile = localStorage.getItem('currentProfile') || 'agil_1';
 applyProfile(savedProfile);
-
-document.getElementById('profileSelect').addEventListener('change', e => {
-    applyProfile(e.target.value);
-});
+updateCalculations();

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <aside id="sidebar">
         <header>
             <h1>Comisiones SERSA</h1>
-            <select id="profileSelect">
+            <select id="profileSelect" onchange="changeProfile(this.value)">
                 <option value="agil_1">Ágil 1</option>
                 <option value="agil_2">Ágil 2</option>
                 <option value="empresarial_1">Empresarial 1</option>


### PR DESCRIPTION
## Summary
- trigger recalculations when changing profile
- keep selected profile in `localStorage` under `currentProfile`
- hook `changeProfile` from header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ee9ac24d8832fb1d1d48be00773d5