### PR TITLE
Format monetary inputs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,18 @@ let multMora;
 
 const STORAGE_KEY = 'commission_profiles';
 
+function parseMoney(value) {
+    if (typeof value === 'number') return value;
+    if (!value) return 0;
+    return Number(value.toString().replace(/\./g, ''));
+}
+
+function formatMoney(value) {
+    const num = parseMoney(value);
+    if (isNaN(num)) return '';
+    return num.toLocaleString('es-ES');
+}
+
 function loadStoredProfiles() {
     try {
         const stored = localStorage.getItem(STORAGE_KEY);
@@ -177,9 +189,9 @@ function getMult(valor, tabla) {
 }
 
 function calcular() {
-    const montoInterno = Number(document.getElementById('montoInterno').value) || 0;
-    const montoExterno = Number(document.getElementById('montoExterno').value) || 0;
-    const montoRecuperado = Number(document.getElementById('montoRecuperado').value) || 0;
+    const montoInterno = parseMoney(document.getElementById('montoInterno').value) || 0;
+    const montoExterno = parseMoney(document.getElementById('montoExterno').value) || 0;
+    const montoRecuperado = parseMoney(document.getElementById('montoRecuperado').value) || 0;
     const cantidad = Number(document.getElementById('cantidad').value) || 0;
     const menorSemana = Number(document.getElementById('menorSemana').value) || 0;
     const conv = Number(document.getElementById('conv').value) || 0;
@@ -241,8 +253,24 @@ document.querySelectorAll('#datosForm input, #datosForm select').forEach(el => {
     el.addEventListener('input', calcular);
 });
 
+function initMoneyFormat() {
+    ['montoInterno', 'montoExterno', 'montoRecuperado'].forEach(id => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('blur', () => {
+            el.value = formatMoney(el.value);
+            calcular();
+        });
+        el.addEventListener('focus', () => {
+            const val = parseMoney(el.value);
+            el.value = val ? val : '';
+        });
+    });
+}
+
 document.getElementById('pdfButton').addEventListener('click', descargarPDF);
 
 const savedProfile = localStorage.getItem('currentProfile') || 'agil_1';
 applyProfile(savedProfile);
+initMoneyFormat();
 updateCalculations();

--- a/src/index.html
+++ b/src/index.html
@@ -30,15 +30,15 @@
                     <option value="5">Genio</option>
                 </select>
             </label>
-            <label>Monto Interno* <input type="number" id="montoInterno" required></label>
+            <label>Monto Interno* <input type="text" id="montoInterno" inputmode="numeric" required></label>
             <div id="progInterno" class="progress">
                 <div></div><div></div><div></div><div></div><div></div><div></div>
             </div>
-            <label>Monto Externo* <input type="number" id="montoExterno" required></label>
+            <label>Monto Externo* <input type="text" id="montoExterno" inputmode="numeric" required></label>
             <div id="progExterno" class="progress">
                 <div></div><div></div><div></div><div></div><div></div><div></div>
             </div>
-            <label>Recuperados* <input type="number" id="montoRecuperado" required></label>
+            <label>Recuperados* <input type="text" id="montoRecuperado" inputmode="numeric" required></label>
             <div id="progRecuperado" class="progress">
                 <div></div><div></div><div></div><div></div><div></div><div></div>
             </div>


### PR DESCRIPTION
## Summary
- add money format helpers in `app.js`
- use parsing helper when calculating values
- format monetary fields on blur
- change monetary inputs to text with numeric keypad hint

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ef54a3c00832f87e854db1dbaf0c0