### PR TITLE
Enhance progress bar styles

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -120,11 +120,14 @@ function updateProgress(id, nivel) {
     if (!bar) return;
     const segs = bar.children;
     for (let i = 0; i < segs.length; i++) {
-        segs[i].classList.remove('reached', 'current');
-        if (nivel > i) segs[i].classList.add('reached');
-    }
-    if (nivel >= 0 && nivel < segs.length) {
-        segs[nivel].classList.add('current');
+        segs[i].classList.remove('reached', 'current', 'unreached');
+        if (i < nivel) {
+            segs[i].classList.add('reached');
+        } else if (i === nivel) {
+            segs[i].classList.add('current');
+        } else {
+            segs[i].classList.add('unreached');
+        }
     }
 }
 
@@ -148,7 +151,16 @@ function initProgressBars() {
         const bar = document.getElementById(c.bar);
         if (!bar) return;
         Array.from(bar.children).forEach((seg, i) => {
-            seg.addEventListener('click', () => {
+            seg.addEventListener('click', (e) => {
+                const ripple = document.createElement('span');
+                const size = Math.max(seg.clientWidth, seg.clientHeight);
+                const rect = seg.getBoundingClientRect();
+                ripple.className = 'ripple';
+                ripple.style.width = ripple.style.height = size + 'px';
+                ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+                ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+                seg.appendChild(ripple);
+                ripple.addEventListener('animationend', () => ripple.remove());
                 document.getElementById(c.input).value = c.metas[i];
                 calcular();
             });

--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -54,16 +54,42 @@ input:not(:placeholder-shown) {
 }
 .progress div {
     flex: 1;
-    background: #ddd;
+    background: #F5F5F5;
     margin-right: 2px;
     cursor: pointer;
+    transition: background 0.3s, transform 0.2s, box-shadow 0.2s;
+    position: relative;
+    overflow: hidden;
 }
 .progress div:last-child {
     margin-right: 0;
 }
+.progress div.unreached {
+    background: #F5F5F5;
+}
 .progress div.reached {
-    background: #4caf50;
+    background: #C8E6C9;
 }
 .progress div.current {
-    background: #003f7f;
+    background: #006D77;
+}
+.progress div:hover {
+    transform: scale(1.05);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.progress div .ripple {
+    position: absolute;
+    border-radius: 50%;
+    transform: scale(0);
+    background: rgba(255,255,255,0.5);
+    animation: ripple 0.6s linear;
+    pointer-events: none;
+}
+
+@keyframes ripple {
+    to {
+        transform: scale(4);
+        opacity: 0;
+    }
 }


### PR DESCRIPTION
## Summary
- style progress segments using guide colors
- animate segment hover and add ripple effect
- set `unreached`, `reached` and `current` classes dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ef544b5b0832f921aa920baea7e03