### PR TITLE
Add viewport meta and responsive breakpoints

### DIFF
--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -2,13 +2,15 @@ body {
     margin: 0;
     font-family: Arial, sans-serif;
     display: flex;
+    flex-direction: column;
 }
 #container {
     display: flex;
+    flex-direction: column;
     width: 100%;
 }
 #sidebar {
-    width: 320px;
+    width: 100%;
     padding: 20px;
     background: #f4f4f4;
     box-sizing: border-box;
@@ -66,4 +68,38 @@ input:not(:placeholder-shown) {
 }
 .progress div.current {
     background: #003f7f;
+}
+
+/* Responsive Breakpoints */
+@media (min-width: 576px) {
+    /* Landscape phones */
+    #sidebar {
+        width: 80%;
+        margin: 0 auto;
+    }
+}
+
+@media (min-width: 768px) {
+    /* Tablets */
+    #container {
+        flex-direction: row;
+    }
+    #sidebar {
+        width: 280px;
+        margin: 0;
+    }
+}
+
+@media (min-width: 992px) {
+    /* Desktop */
+    #sidebar {
+        width: 320px;
+    }
+}
+
+@media (min-width: 1200px) {
+    /* Large desktop */
+    #sidebar {
+        width: 360px;
+    }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Sistema de Comisiones - SERSA</title>
     <link rel="stylesheet" href="comisiones.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- make the layout mobile-friendly by adding `<meta name="viewport">`
- switch `comisiones.css` to a mobile-first layout
- add responsive CSS breakpoints based on the UI/UX guide

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ef53fbc24832f9d7ed0e7df3d18a7