### PR TITLE
Unify color variables across frontend and admin

### DIFF
--- a/src/admin.css
+++ b/src/admin.css
@@ -1,9 +1,15 @@
 :root {
-    --admin-primary: #006D77;
-    --admin-secondary: #83C5BE;
-    --admin-danger: #F44336;
-    --admin-success: #4CAF50;
-    --admin-warning: #FFA726;
+    --primary: #006D77;
+    --primary-light: #83C5BE;
+    --secondary: #EDF6F9;
+    --danger: #F44336;
+    --success: #4CAF50;
+    --warning: #FFA726;
+    --info: #2196F3;
+    --dark: #212121;
+    --gray: #757575;
+    --light-gray: #E0E0E0;
+    --background: #F5F6F8;
 }
 
 /* Login Screen */
@@ -13,7 +19,7 @@
     align-items: center;
     justify-content: center;
     height: 100vh;
-    background: linear-gradient(135deg, var(--admin-secondary) 0%, var(--admin-primary) 100%);
+    background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary) 100%);
 }
 
 .login-container h1 {
@@ -41,11 +47,11 @@
 /* Admin Panel */
 .admin-panel {
     min-height: 100vh;
-    background: #f5f6f8;
+    background: var(--background);
 }
 
 .admin-header {
-    background: var(--admin-primary);
+    background: var(--primary);
     color: white;
     padding: 20px;
     display: flex;
@@ -68,7 +74,7 @@
 }
 
 .btn-save {
-    background: var(--admin-success);
+    background: var(--success);
     color: white;
 }
 
@@ -77,12 +83,12 @@
 }
 
 .btn-export, .btn-import {
-    background: var(--admin-secondary);
+    background: var(--primary-light);
     color: white;
 }
 
 .btn-logout {
-    background: var(--admin-danger);
+    background: var(--danger);
     color: white;
 }
 
@@ -110,7 +116,7 @@
 }
 
 .profile-tab.active {
-    background: var(--admin-primary);
+    background: var(--primary);
     color: white;
 }
 
@@ -128,7 +134,7 @@
 }
 
 .config-section h2 {
-    color: var(--admin-primary);
+    color: var(--primary);
     margin-bottom: 15px;
     padding-bottom: 10px;
     border-bottom: 2px solid #eee;
@@ -141,7 +147,7 @@
 }
 
 .config-table th {
-    background: var(--admin-secondary);
+    background: var(--primary-light);
     color: white;
     padding: 12px;
     text-align: left;
@@ -161,7 +167,7 @@
 }
 
 .table-input:focus {
-    border-color: var(--admin-primary);
+    border-color: var(--primary);
     outline: none;
 }
 
@@ -184,7 +190,7 @@
 }
 
 .multiplicador-config h4 {
-    color: var(--admin-primary);
+    color: var(--primary);
     margin-bottom: 10px;
 }
 
@@ -207,7 +213,7 @@
     padding: 20px;
     margin: 20px;
     border-radius: 8px;
-    border: 2px solid var(--admin-warning);
+    border: 2px solid var(--warning);
 }
 
 .changes-list {
@@ -226,7 +232,7 @@
 
 .change-field {
     font-weight: bold;
-    color: var(--admin-primary);
+    color: var(--primary);
 }
 
 /* History Section */
@@ -244,7 +250,7 @@
 
 .btn-detail {
     padding: 5px 10px;
-    background: var(--admin-secondary);
+    background: var(--primary-light);
     color: white;
     border: none;
     border-radius: 4px;

--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -1,3 +1,17 @@
+:root {
+    --primary: #006D77;
+    --primary-light: #83C5BE;
+    --secondary: #EDF6F9;
+    --success: #4CAF50;
+    --warning: #FFA726;
+    --danger: #F44336;
+    --info: #2196F3;
+    --dark: #212121;
+    --gray: #757575;
+    --light-gray: #E0E0E0;
+    --background: #F5F6F8;
+}
+
 body {
     margin: 0;
     font-family: Arial, sans-serif;
@@ -10,7 +24,7 @@ body {
 #sidebar {
     width: 320px;
     padding: 20px;
-    background: #f4f4f4;
+    background: var(--secondary);
     box-sizing: border-box;
 }
 #sidebar header {
@@ -38,10 +52,10 @@ input, select {
     box-sizing: border-box;
 }
 input:required:invalid {
-    border: 1px solid red;
+    border: 1px solid var(--danger);
 }
 input:not(:placeholder-shown) {
-    border: 1px solid green;
+    border: 1px solid var(--success);
 }
 #comisionTotal {
     font-size: 24px;
@@ -54,7 +68,7 @@ input:not(:placeholder-shown) {
 }
 .progress div {
     flex: 1;
-    background: #ddd;
+    background: var(--light-gray);
     margin-right: 2px;
     cursor: pointer;
 }
@@ -62,8 +76,8 @@ input:not(:placeholder-shown) {
     margin-right: 0;
 }
 .progress div.reached {
-    background: #4caf50;
+    background: var(--success);
 }
 .progress div.current {
-    background: #003f7f;
+    background: var(--primary);
 }


### PR DESCRIPTION
## Summary
- define shared palette variables in `comisiones.css`
- rename `--admin-*` variables in `admin.css` to use the shared names
- update selectors to reference the new variables

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ef548cd3c832fb3123596e5a38f33