### PR TITLE
Add input state styling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -237,8 +237,24 @@ function descargarPDF() {
     doc.save('comision.pdf');
 }
 
+function updateInputState(el) {
+    el.classList.remove('empty-required', 'empty-optional', 'filled', 'error');
+    if (el.value.trim() === '') {
+        el.classList.add(el.required ? 'empty-required' : 'empty-optional');
+    } else {
+        el.classList.add('filled');
+        if (!el.checkValidity()) {
+            el.classList.add('error');
+        }
+    }
+}
+
 document.querySelectorAll('#datosForm input, #datosForm select').forEach(el => {
-    el.addEventListener('input', calcular);
+    const update = () => updateInputState(el);
+    el.addEventListener('input', () => { update(); calcular(); });
+    el.addEventListener('focus', () => el.classList.add('focus'));
+    el.addEventListener('blur', () => { el.classList.remove('focus'); update(); });
+    update();
 });
 
 document.getElementById('pdfButton').addEventListener('click', descargarPDF);

--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -37,12 +37,6 @@ input, select {
     margin-bottom: 10px;
     box-sizing: border-box;
 }
-input:required:invalid {
-    border: 1px solid red;
-}
-input:not(:placeholder-shown) {
-    border: 1px solid green;
-}
 #comisionTotal {
     font-size: 24px;
     font-weight: bold;
@@ -66,4 +60,32 @@ input:not(:placeholder-shown) {
 }
 .progress div.current {
     background: #003f7f;
+}
+
+/* Input state classes */
+.empty-required {
+    border: 1px solid #F44336;
+    background: #FFEBEE;
+}
+.empty-optional {
+    border: 1px solid #FFA726;
+    background: #FFF8E1;
+}
+.filled {
+    border: 1px solid #4CAF50;
+}
+.focus {
+    border: 1px solid #2196F3;
+    box-shadow: 0 0 4px rgba(33, 150, 243, 0.6);
+    transform: scale(1.01);
+}
+.error {
+    border: 1px solid #F44336;
+    animation: shake 0.3s;
+}
+@keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-2px); }
+    50% { transform: translateX(2px); }
+    75% { transform: translateX(-2px); }
 }


### PR DESCRIPTION
## Summary
- style inputs for required/optional/filled/focus/error states
- toggle CSS classes on inputs during interaction and validation

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_685ef545d2e8832f91b129ddedd2760f