### PR TITLE
Improve PDF menu accessibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -273,8 +273,43 @@ function initMoneyFormat() {
 
 function togglePDFMenu() {
     const menu = document.getElementById('pdfMenuOptions');
-    if (!menu) return;
-    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+    const btn = document.querySelector('.pdf-menu > button');
+    if (!menu || !btn) return;
+    menu.classList.toggle('open');
+    const isOpen = menu.classList.contains('open');
+    btn.setAttribute('aria-expanded', isOpen);
+    if (isOpen) {
+        document.addEventListener('click', handleOutsideClick);
+        document.addEventListener('keydown', handleEscape);
+    } else {
+        document.removeEventListener('click', handleOutsideClick);
+        document.removeEventListener('keydown', handleEscape);
+    }
+}
+
+function closePDFMenu() {
+    const menu = document.getElementById('pdfMenuOptions');
+    const btn = document.querySelector('.pdf-menu > button');
+    if (!menu || !btn) return;
+    if (menu.classList.contains('open')) {
+        menu.classList.remove('open');
+        btn.setAttribute('aria-expanded', 'false');
+        document.removeEventListener('click', handleOutsideClick);
+        document.removeEventListener('keydown', handleEscape);
+    }
+}
+
+function handleOutsideClick(e) {
+    const container = document.querySelector('.pdf-menu');
+    if (container && !container.contains(e.target)) {
+        closePDFMenu();
+    }
+}
+
+function handleEscape(e) {
+    if (e.key === 'Escape') {
+        closePDFMenu();
+    }
 }
 
 setupPDFGeneration();

--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -143,6 +143,7 @@ input:not(:placeholder-shown) {
 }
 
 .pdf-menu-options {
+    display: none;
     position: absolute;
     top: 100%;
     right: 0;
@@ -152,6 +153,10 @@ input:not(:placeholder-shown) {
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     z-index: 1000;
     min-width: 180px;
+}
+
+.pdf-menu-options.open {
+    display: block;
 }
 
 .pdf-menu-options button {

--- a/src/index.html
+++ b/src/index.html
@@ -21,10 +21,10 @@
                 <option value="empresarial_2">Empresarial 2</option>
             </select>
             <div class="pdf-menu">
-                <button type="button" class="header-btn" onclick="togglePDFMenu()">📄 PDF ▼</button>
-                <div class="pdf-menu-options" id="pdfMenuOptions" style="display: none;">
-                    <button type="button" onclick="descargarPDF()">📄 PDF Simple</button>
-                    <button type="button" onclick="generateProfessionalPDF()">📊 PDF Profesional</button>
+                <button type="button" class="header-btn" onclick="togglePDFMenu()" aria-haspopup="true" aria-expanded="false">📄 PDF ▼</button>
+                <div class="pdf-menu-options" id="pdfMenuOptions" role="menu">
+                    <button type="button" role="menuitem" onclick="descargarPDF()">📄 PDF Simple</button>
+                    <button type="button" role="menuitem" onclick="generateProfessionalPDF()">📊 PDF Profesional</button>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## Summary
- use CSS classes instead of inline styles for the PDF menu
- close the menu on outside click or Esc
- add ARIA roles to PDF menu

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f03a14824832fb1a72101d9104cdc