### PR TITLE
Improve progress bar accessibility

### DIFF
--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -33,8 +33,20 @@ export function initProgressBars(metas) {
         const bar = document.getElementById(c.bar);
         if (!bar) return;
         Array.from(bar.children).forEach((seg, i) => {
-            seg.addEventListener('click', () => {
+            seg.setAttribute('tabindex', '0');
+            seg.setAttribute('role', 'button');
+            seg.setAttribute('aria-label', String(c.metas[i]));
+
+            const updateValue = () => {
                 document.getElementById(c.input).value = c.metas[i];
+            };
+
+            seg.addEventListener('click', updateValue);
+            seg.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    updateValue();
+                }
             });
         });
     });


### PR DESCRIPTION
## Summary
- add `tabindex`, `role` and aria labels to progress bar segments
- allow keyboard activation of each segment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f08e691b8832f85133586fa0ce685