### PR TITLE
Restore pdf menu helpers and money format

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -96,6 +96,7 @@ document.querySelectorAll('#datosForm input, #datosForm select').forEach(el => {
 
 setupPDFGeneration();
 
+window.calcular = calcular;
 window.changeProfile = changeProfile;
 window.togglePDFMenu = togglePDFMenu;
 window.descargarPDF = descargarPDF;

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -46,6 +46,7 @@ export function initMoneyFormat() {
         if (!el) return;
         el.addEventListener('blur', () => {
             el.value = formatMoney(el.value);
+            if (window.calcular) window.calcular();
         });
         el.addEventListener('focus', () => {
             const val = parseMoney(el.value);
@@ -56,6 +57,41 @@ export function initMoneyFormat() {
 
 export function togglePDFMenu() {
     const menu = document.getElementById('pdfMenuOptions');
-    if (!menu) return;
-    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+    const btn = document.querySelector('.pdf-menu > button');
+    if (!menu || !btn) return;
+    menu.classList.toggle('open');
+    const isOpen = menu.classList.contains('open');
+    btn.setAttribute('aria-expanded', isOpen);
+    if (isOpen) {
+        document.addEventListener('click', handleOutsideClick);
+        document.addEventListener('keydown', handleEscape);
+    } else {
+        document.removeEventListener('click', handleOutsideClick);
+        document.removeEventListener('keydown', handleEscape);
+    }
+}
+
+export function closePDFMenu() {
+    const menu = document.getElementById('pdfMenuOptions');
+    const btn = document.querySelector('.pdf-menu > button');
+    if (!menu || !btn) return;
+    if (menu.classList.contains('open')) {
+        menu.classList.remove('open');
+        btn.setAttribute('aria-expanded', 'false');
+        document.removeEventListener('click', handleOutsideClick);
+        document.removeEventListener('keydown', handleEscape);
+    }
+}
+
+function handleOutsideClick(e) {
+    const container = document.querySelector('.pdf-menu');
+    if (container && !container.contains(e.target)) {
+        closePDFMenu();
+    }
+}
+
+function handleEscape(e) {
+    if (e.key === 'Escape') {
+        closePDFMenu();
+    }
 }


### PR DESCRIPTION
## Summary
- expose `calcular` globally so other modules can use it
- refresh money fields on blur and re-run calculation
- improve PDF menu behavior with open/close helpers

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685f08d9cd14832fbc578fe432e9cfc8