### PR TITLE
Add interactive Chart.js visualizations

### DIFF
--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -252,3 +252,24 @@ button:active::after {
     from { opacity: 0.4; }
     to { opacity: 1; }
 }
+
+/* Charts */
+#chartComision,
+#chartComparativo {
+    display: block;
+    max-width: 400px;
+    margin: 1rem auto;
+}
+
+#gauges {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+#gauges canvas {
+    width: 120px !important;
+    height: 80px !important;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -136,6 +136,13 @@
             </div>
         </div>
         <canvas id="chartComision" width="300" height="300" aria-label="Composición"></canvas>
+        <canvas id="chartComparativo" width="300" height="200" aria-label="Cumplimiento"></canvas>
+        <div id="gauges">
+            <canvas id="gaugeConv" width="120" height="60" aria-label="Conv"></canvas>
+            <canvas id="gaugeEmp" width="120" height="60" aria-label="Emp"></canvas>
+            <canvas id="gaugeProc" width="120" height="60" aria-label="Proc"></canvas>
+            <canvas id="gaugeMora" width="120" height="60" aria-label="Mora"></canvas>
+        </div>
         <section id="detalle"></section>
     </main>
     </div>


### PR DESCRIPTION
## Summary
- add comparative and gauge charts to index.html
- style charts with new CSS rules
- implement Chart.js bar and gauge charts with needle plugin
- update calculations to refresh all charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1a622804832fa178ad9c27a91246