### PR TITLE
Add dark mode and basic onboarding

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -126,6 +126,42 @@ function initGaugeCharts() {
     gaugeCharts.mora = createGauge('gaugeMora');
 }
 
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+    const toggle = document.getElementById('themeToggle');
+    if (toggle) toggle.checked = theme === 'dark';
+}
+
+function toggleTheme() {
+    const current = localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+    applyTheme(current === 'dark' ? 'light' : 'dark');
+}
+
+function initTheme() {
+    const stored = localStorage.getItem('theme') || 'light';
+    applyTheme(stored);
+    const toggle = document.getElementById('themeToggle');
+    if (toggle) toggle.addEventListener('change', toggleTheme);
+}
+
+function initTour() {
+    const hide = localStorage.getItem('hideTour');
+    if (!hide) {
+        const overlay = document.getElementById('tourOverlay');
+        if (overlay) overlay.classList.remove('hidden');
+    }
+}
+
+function closeTour() {
+    const dont = document.getElementById('dontShowTour');
+    if (dont && dont.checked) {
+        localStorage.setItem('hideTour', '1');
+    }
+    const overlay = document.getElementById('tourOverlay');
+    if (overlay) overlay.classList.add('hidden');
+}
+
 let profiles = loadStoredProfiles() || cloneConfig(defaultProfiles);
 
 let currentProfile = 'agil_1';
@@ -253,6 +289,8 @@ window.calcular = calcular;
 window.changeProfile = changeProfile;
 window.togglePDFMenu = togglePDFMenu;
 window.descargarPDF = descargarPDF;
+window.toggleTheme = toggleTheme;
+window.closeTour = closeTour;
 
 const savedProfile = localStorage.getItem('currentProfile') || 'agil_1';
 applyProfile(savedProfile);
@@ -260,4 +298,6 @@ initMoneyFormat();
 initChart();
 initBarChart();
 initGaugeCharts();
+initTheme();
+initTour();
 updateCalculations();

--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -12,10 +12,21 @@
     --background: #F5F6F8;
 }
 
+[data-theme='dark'] {
+    --primary: #83C5BE;
+    --primary-light: #006D77;
+    --secondary: #1e1e1e;
+    --background: #121212;
+    --dark: #F5F6F8;
+    --gray: #bdbdbd;
+    --light-gray: #555;
+}
+
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto;
     background: linear-gradient(135deg, var(--primary), var(--primary-light));
+    color: var(--dark);
     min-height: 100vh;
 }
 
@@ -273,3 +284,70 @@ button:active::after {
     width: 120px !important;
     height: 80px !important;
 }
+
+/* Theme toggle */
+.theme-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 0.5rem;
+}
+
+#themeToggle {
+    width: 40px;
+    height: 20px;
+    appearance: none;
+    background: var(--light-gray);
+    border-radius: 10px;
+    position: relative;
+    cursor: pointer;
+    outline: none;
+    transition: background 0.3s;
+}
+
+#themeToggle:checked {
+    background: var(--primary);
+}
+
+#themeToggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.3s;
+}
+
+#themeToggle:checked::after {
+    transform: translateX(20px);
+}
+
+/* Onboarding overlay */
+.tour-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    padding: 20px;
+}
+
+.tour-overlay.hidden {
+    display: none;
+}
+
+.tour-content {
+    background: var(--secondary);
+    color: var(--dark);
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 400px;
+    text-align: center;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+

--- a/src/index.html
+++ b/src/index.html
@@ -21,6 +21,10 @@
                 <option value="empresarial_1">Empresarial 1</option>
                 <option value="empresarial_2">Empresarial 2</option>
             </select>
+            <label class="theme-switch" for="themeToggle">
+                <input type="checkbox" id="themeToggle" aria-label="Modo oscuro">
+                <span>🌙</span>
+            </label>
             <div class="pdf-menu">
                 <button type="button" class="header-btn" onclick="togglePDFMenu()" aria-haspopup="true" aria-expanded="false">📄 PDF ▼</button>
                 <div class="pdf-menu-options" id="pdfMenuOptions" role="menu">
@@ -145,6 +149,13 @@
         </div>
         <section id="detalle"></section>
     </main>
+    </div>
+</div>
+<div id="tourOverlay" class="tour-overlay hidden">
+    <div class="tour-content">
+        <p>Bienvenido al sistema de comisiones. Aquí podrás ingresar tus datos y ver el resultado en tiempo real.</p>
+        <label><input type="checkbox" id="dontShowTour"> No mostrar de nuevo</label>
+        <button onclick="closeTour()">Cerrar</button>
     </div>
 </div>
 <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- implement dark theme variables in CSS
- add theme toggle switch and onboarding overlay to HTML
- support theme persistence and basic tour logic in app

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1a78fbf0832f9c7eba1cfb9f76fa