### PR TITLE
Formato guaraní en toda la aplicación

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -1,3 +1,5 @@
+import { formatMoney as formatGuarani } from './modules/validators.js';
+
 class ProfileStorage {
     static STORAGE_KEY = 'commission_profiles';
 
@@ -406,7 +408,7 @@ class AdminPanel {
     }
 
     formatMoney(value) {
-        return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.') + ' Gs';
+        return formatGuarani(value) + ' Gs';
     }
 
     selectProfile(profileId) {

--- a/src/app.js
+++ b/src/app.js
@@ -23,7 +23,7 @@ function animateValue(el, start, end) {
     function step(time) {
         const progress = Math.min((time - startTime) / duration, 1);
         const value = Math.floor(progress * (end - start) + start);
-        el.textContent = value.toLocaleString('es-ES');
+        el.textContent = formatMoney(value);
         if (progress < 1) requestAnimationFrame(step);
     }
     requestAnimationFrame(step);
@@ -225,7 +225,7 @@ function calcular() {
     animateValue(totalEl, prev, resultado.total);
 
     document.getElementById('kpiNivel').innerText = resultado.nivelCarreraFinal >= 0 ? niveles[resultado.nivelCarreraFinal] : 'Sin nivel';
-    document.getElementById('kpiSubtotal').innerText = resultado.subtotal.toLocaleString('es-ES');
+    document.getElementById('kpiSubtotal').innerText = formatMoney(resultado.subtotal);
     document.getElementById('kpiMultiplicador').innerText = resultado.multiplicador.toFixed(2);
 
     if (donutChart) {
@@ -264,7 +264,7 @@ function calcular() {
 
     document.getElementById('detalle').innerHTML = `
         <p>Nivel Carrera: ${resultado.nivelCarreraFinal >= 0 ? niveles[resultado.nivelCarreraFinal] : 'Sin nivel'}</p>
-        <p>Subtotal: ${resultado.subtotal.toLocaleString('es-ES')}</p>
+        <p>Subtotal: ${formatMoney(resultado.subtotal)}</p>
         <p>Multiplicador: ${resultado.multiplicador.toFixed(2)}</p>
     `;
 }

--- a/src/modules/validators.js
+++ b/src/modules/validators.js
@@ -9,5 +9,5 @@ export function parseMoney(value) {
 export function formatMoney(value) {
     const num = parseMoney(value);
     if (isNaN(num)) return '';
-    return num.toLocaleString('es-ES');
+    return num.toLocaleString('es-PY');
 }

--- a/src/pdf-generator.js
+++ b/src/pdf-generator.js
@@ -1,6 +1,7 @@
 import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import Chart from 'chart.js/auto';
+import { parseMoney, formatMoney as formatGuarani } from './modules/validators.js';
 
 export class PDFGenerator {
   constructor() {
@@ -295,7 +296,7 @@ export class PDFGenerator {
   }
 
   formatMoney(value) {
-    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+    return formatGuarani(value);
   }
 
   getProgressBar(current, target) {


### PR DESCRIPTION
## Summary
- unify money formatting using Guaraní locale
- update UI to show numbers with `formatMoney`
- reuse the same formatter in admin panel and PDF generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f21437818832fac1b35d3ed1e7e2b