### PR TITLE
Add shine animation to progress segments

### DIFF
--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -252,7 +252,7 @@ button:active::after {
 
 .progress-segment.reached {
     background: var(--success);
-    animation: fill 0.5s forwards;
+    animation: fill 0.5s forwards, shine 0.6s;
 }
 
 .progress-segment.current {
@@ -262,6 +262,12 @@ button:active::after {
 @keyframes fill {
     from { opacity: 0.4; }
     to { opacity: 1; }
+}
+
+@keyframes shine {
+    0% { box-shadow: 0 0 0 0 var(--success); }
+    50% { box-shadow: 0 0 8px 4px var(--success); }
+    100% { box-shadow: 0 0 0 0 var(--success); }
 }
 
 /* Charts */

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -4,13 +4,25 @@ export function updateProgress(id, nivel) {
     const bar = document.getElementById(id);
     if (!bar) return;
     const segs = bar.children;
+    const prev = parseInt(bar.dataset.level ?? '-1', 10);
     for (let i = 0; i < segs.length; i++) {
-        segs[i].classList.remove('reached', 'current');
-        if (nivel > i) segs[i].classList.add('reached');
+        segs[i].classList.remove('current');
+        if (nivel > i) {
+            if (i > prev) {
+                segs[i].classList.remove('reached');
+                void segs[i].offsetWidth;
+                segs[i].classList.add('reached');
+            } else {
+                segs[i].classList.add('reached');
+            }
+        } else {
+            segs[i].classList.remove('reached');
+        }
     }
     if (nivel >= 0 && nivel < segs.length) {
         segs[nivel].classList.add('current');
     }
+    bar.dataset.level = nivel;
 }
 
 export function resetProgressBars() {


### PR DESCRIPTION
## Summary
- add `shine` keyframes in `comisiones.css`
- trigger the new glow animation on `.progress-segment.reached`
- tweak `updateProgress` to restart the animation when segments become reached

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f39c1a858832fab3997ccbd7be67b