### PR TITLE
Add confetti celebration for Genio achievement

### DIFF
--- a/src/comisiones.css
+++ b/src/comisiones.css
@@ -579,3 +579,15 @@ button:active::after {
     font-weight: bold;
 }
 
+/* Confetti Canvas */
+#confettiCanvas {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 3000;
+}
+
+.confetti.hidden {
+    display: none;
+}
+

--- a/src/index.html
+++ b/src/index.html
@@ -262,6 +262,7 @@
         <ul id="qsHistory" class="qs-history"></ul>
     </div>
 </div>
+<canvas id="confettiCanvas" class="confetti hidden" aria-hidden="true"></canvas>
 <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/src/modules/gamification.js
+++ b/src/modules/gamification.js
@@ -11,6 +11,38 @@ const motivationalQuotes = [
 let unlocked = [];
 let lastResult = {};
 
+function renderConfetti() {
+    const canvas = document.getElementById('confettiCanvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width = window.innerWidth;
+    const height = canvas.height = window.innerHeight;
+    canvas.classList.remove('hidden');
+
+    const pieces = Array.from({ length: 100 }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height - height,
+        size: 5 + Math.random() * 5,
+        color: `hsl(${Math.random() * 360},100%,50%)`,
+        speed: Math.random() * 3 + 2
+    }));
+
+    function draw() {
+        ctx.clearRect(0, 0, width, height);
+        pieces.forEach(p => {
+            p.y += p.speed;
+            ctx.fillStyle = p.color;
+            ctx.fillRect(p.x, p.y, p.size, p.size);
+        });
+        if (pieces.some(p => p.y < height)) {
+            requestAnimationFrame(draw);
+        } else {
+            canvas.classList.add('hidden');
+        }
+    }
+    draw();
+}
+
 function loadAchievements() {
     try {
         const data = localStorage.getItem(ACH_KEY);
@@ -115,6 +147,7 @@ export function checkAchievements(result) {
             unlocked.push(a.id);
             saveAchievements();
             showAchievement(a);
+            if (a.id === 'genio') renderConfetti();
         }
     });
     updateProgressRing(result.total);


### PR DESCRIPTION
## Summary
- add hidden canvas element for confetti
- style confetti canvas overlay and hide when inactive
- implement `renderConfetti` in gamification module
- trigger confetti when Genio achievement is unlocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f39e0adc8832f8666f8b170257934